### PR TITLE
Migrate frontend registration urls to use myunderstory

### DIFF
--- a/components/Editor.jsx
+++ b/components/Editor.jsx
@@ -11,6 +11,7 @@ import {
   addUrl
 } from '@inrupt/solid-client'
 
+// TODO: remove old coop.itme.host references
 export default function Editor ({ body }){
   const editor = useNewEditor()
   const [value, setValue] = useState(body)

--- a/utils/fetch.js
+++ b/utils/fetch.js
@@ -18,14 +18,14 @@ export async function postFormData(uri, body){
 
 }
 
-const SolidServerURI = "https://coop.itme.host"
+const SolidServerURI = "https://myunderstory.com"
 
 export async function sendMagicLink(username, email) {
   const magicLinkURI = SolidServerURI + "/magic-link/generate"
   console.log("Sending magic link to " + email)
   return postFormData(magicLinkURI, {
     username, email,
-    returnToUrl: `https://itme.online/login/${username}.coop.itme.host`
+    returnToUrl: `https://understory.garden/login/${username}.myunderstory.com`
   })
 }
 


### PR DESCRIPTION
The register page was still using coop.itme.host.