### PR TITLE
add usesCSS and monetizedFor to gate configs

### DIFF
--- a/model/gnomes.jsx
+++ b/model/gnomes.jsx
@@ -26,19 +26,23 @@ export function randomReadableId() {
   return greg.sentence().replace(/\s+/g, '-').toLowerCase()
 }
 
-export function newSinglePageGateThing(webId, conceptPrefix, index, concept) {
+export function newSinglePageGateThing(webId, conceptPrefix, index, concept, css) {
   let thing = createThing()
   thing = setStringNoLocale(thing, US.hasGnomeType, GnomeType.Gate)
   thing = setStringNoLocale(thing, US.usesGateTemplate, GateTemplate.SinglePageGate)
   thing = setStringNoLocale(thing, US.conceptPrefix, conceptPrefix)
+  thing = setStringNoLocale(thing, US.usesCSS, css)
+  thing = setUrl(thing, US.monetizedFor, webId)
   thing = setUrl(thing, US.usesConcept, asUrl(concept))
   thing = setUrl(thing, US.usesConceptIndex, getSourceUrl(index))
   return thing
 }
 
-export function updateSinglePageGateThing(thing, conceptPrefix, index, concept){
+export function updateSinglePageGateThing(thing, webId, conceptPrefix, index, concept, css){
   let updatedThing = setUrl(thing, US.usesConcept, asUrl(concept));
   updatedThing = setStringNoLocale(updatedThing, US.conceptPrefix, conceptPrefix)
+  updatedThing = setStringNoLocale(updatedThing, US.usesCSS, css)
+  updatedThing = setUrl(updatedThing, US.monetizedFor, webId)
   updatedThing = setUrl(updatedThing, US.usesConceptIndex, getSourceUrl(index));
   return updatedThing
 }

--- a/pages/register.jsx
+++ b/pages/register.jsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
 import { Formik, Field, Form } from 'formik';
-import { fetch } from 'solid-auth-fetcher'
 import * as Yup from 'yup';
 import Nav from '../components/nav'
 

--- a/pages/settings.jsx
+++ b/pages/settings.jsx
@@ -130,7 +130,7 @@ function GnomeThingEditor({ webId, thing, updateThing, cancelAdd}) {
             ) : (
               <div className="flex justify-between">
                 <h5 className="font-bold">{chosenConceptName}</h5>
-                <button className="btn" onClick={() => setEditingAll(true)}>Pick a different note</button>
+                <button className="btn" onClick={() => setEditingNoteName(true)}>Pick a different note</button>
               </div>
             )}
           </div>
@@ -142,7 +142,7 @@ function GnomeThingEditor({ webId, thing, updateThing, cancelAdd}) {
       ) : (
         <div className="flex justify-between mt-3">
           <GnomeThingEntry thing={thing} />
-          <button className="btn" onClick={() => setEditingAll(true)}>Edit Gate</button>
+          <button className="btn" onClick={() => setEditingGate(true)}>Edit Gate</button>
         </div>
       )}
     </div>
@@ -154,6 +154,7 @@ function GnomesResourceEditor({ webId }) {
   const [addingNewGnome, setAddingNewGnome] = useState(false)
   const gnomeThings = resource && getThingAll(resource)
   async function updateThing(newThing) {
+    setAddingNewGnome(false)
     const newResource = setThing(resource, newThing)
     await save(newResource)
     const resourceUrl = getSourceUrl(newResource)
@@ -165,7 +166,6 @@ function GnomesResourceEditor({ webId }) {
     const deployedResource = setThing(newResource, deployedThing)
     await save(deployedResource)
     console.log(`Finished setting up gnome at url: ${thingUrl}`)
-    setAddingNewGnome(false)
   }
   function cancel() {
     setAddingNewGnome(false)

--- a/pages/settings.jsx
+++ b/pages/settings.jsx
@@ -105,7 +105,6 @@ function GnomeThingEditor({ webId, thing, updateThing, cancelAdd }) {
   const { concept, index } = useConcept(webId, 'default', chosenConceptName)
 
   async function save({css}) {
-    console.log("saving with CSS", css)
     if (isNewThing) {
       const newThing = newSinglePageGateThing(webId, conceptPrefix, index, concept, css)
       await updateThing(newThing)
@@ -187,13 +186,13 @@ function GnomesResourceEditor({ webId }) {
     await save(newResource)
     const resourceUrl = getSourceUrl(newResource)
     const thingUrl = asUrl(newThing, resourceUrl)
-   /* console.log(`Requesting setup for gnome at url: ${thingUrl}`)
+   console.log(`Requesting setup for gnome at url: ${thingUrl}`)
     const gnomeConfig = await setupGnome({ url: thingUrl })
     let deployedThing = getThing(newResource, thingUrl)
     deployedThing = updateDeploymentStatus(deployedThing, gnomeConfig)
     const deployedResource = setThing(newResource, deployedThing)
     await save(deployedResource)
-    console.log(`Finished setting up gnome at url: ${thingUrl}`)*/
+    console.log(`Finished setting up gnome at url: ${thingUrl}`)
   }
   function cancel() {
     setAddingNewGnome(false)

--- a/vocab.js
+++ b/vocab.js
@@ -51,5 +51,6 @@ export const US = {
   usesConceptIndex: `${understoryRoot}usesConceptIndex`,
   deployedAt: `${understoryRoot}deployedAt`,
   hasGnomeStatus: `${understoryRoot}hasGnomeStatus`,
-
+  monetizedFor: `${understoryRoot}monetizedFor`,
+  usesCSS: `${understoryRoot}usesCSS`
 }


### PR DESCRIPTION
* reset "create new gate" button before saving to avoid weird duplicate ux once the resource has been saved and the new thing exists
* separate gate editing and name editing in prep for more editable fields

AND

    add usesCSS and monetizedFor to gate config

    in doing this I moved to formik, which requires us to store concept name in one additional place - internal formik state

    in the medium run we should extend NewNoteForm to work as a Formik Field and hide this complexity, but we do need to set the component-level chosenConceptName when the user finishes editing the concept name so that the concept can be loaded by useConcept, so some amount of logic will be necessary at this level even then